### PR TITLE
Add .gitattributes file to prevent LF/CRLF normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*assert* -text 


### PR DESCRIPTION
Recreation of #24 on a new branch, see discussion there

GPG was reporting bad signatures, and I traced the issue to Git's turning
LFs into CRLFs when I pulled the repo onto my Windows machine. If anyone
ever somehow gets gitian working on Windows, the opposite is likely to
happen. This should, as I understand it, avoid the issue.
