### PR TITLE
Gitian step-by-step instructions should be of the current release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ It should be updated on each release.
 
 ## How to Make and Submit Gitian Sigs
 
-See [the release process](https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md#perform-gitian-builds)
+See [the release process](https://github.com/bitcoin/bitcoin/blob/0.9.3/doc/release-process.md#perform-gitian-builds)
 in the Bitcoin Core repository on how to build the release archives to create gitian sigs.
 
 [Instructions for setting up a gitian build environment](https://github.com/bitcoin/bitcoin/blob/master/doc/gitian-building.md)


### PR DESCRIPTION
Update README.md later when we are building for newer releases.

The currently linked instructions do not exactly work for the 0.9.3 branch.
