### PR TITLE
Add Travis script to compare assert files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+os: linux
+language: generic
+sudo: false
+branches:
+  only:
+    - master
+script:
+    - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then scripts/compare-sigs.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-language: generic
+language: minimal
 sudo: false
 branches:
   only:

--- a/scripts/compare-sigs.py
+++ b/scripts/compare-sigs.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import subprocess
+
+travis_commit_range = os.getenv('TRAVIS_COMMIT_RANGE')
+if not travis_commit_range:
+    print("Travis commit range is empty, exiting...")
+    sys.exit(0)
+
+try:
+    result = subprocess.check_output(['git', 'diff', '--name-only', travis_commit_range])
+except Exception as e:
+    print(e.output)
+    raise e
+files_added = result.decode('utf-8').split()
+
+for file_added in files_added:
+
+    # Skip files which are not assert files
+    if not file_added.endswith(".assert") or "/" not in file_added:
+        continue
+
+    digests = {}
+    assert_filepath = os.path.abspath(file_added)
+
+    with open(assert_filepath, 'r') as assert_file: 
+        for line in assert_file.readlines():
+            line = line.strip()
+
+            # We only really care about lines containing "bitcoin"
+            if line.startswith("-") or "bitcoin" not in line:
+                continue
+            
+            digest, file = line.split()
+            digests[file] = digest
+    
+    release_version = file_added.split("/", 1)[0]
+    print("Checking", release_version)
+
+    for subdir, dirs, files in os.walk(os.path.abspath(release_version)):
+        for file in files:
+            # Only check .assert files
+            if not file.endswith(".assert"):
+                continue
+
+            filepath = os.path.abspath(os.path.join(subdir, file))
+            # Don't bother checking the same file we've pulled
+            if assert_filepath == filepath:
+                continue
+
+            with open(filepath, 'r') as assert_file:
+                for line in assert_file.readlines():
+                    line = line.strip()
+
+                    if line.startswith("-") or "bitcoin" not in line:
+                        continue
+
+                    try:
+                        digest, file_name = line.split()
+                    except:
+                        continue
+                    
+                    if file_name in digests and digests[file_name] != digest:
+                        print("Mismatch between", assert_filepath, "and", filepath, "for", file_name, ":", digests[file_name], "!=", digest)
+                        sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
As suggested in #607, this adds a simply python script for Travis to run, which compares the assert files of any PR with those already merged in master.

~Example can be seen on master of my repo: https://github.com/MeshCollider/gitian.sigs
I've opened a PR against my repo for my 0.15.1 sigs, which you can see has passed the check: https://github.com/MeshCollider/gitian.sigs/pull/5
And here is an example of a check failing: https://github.com/MeshCollider/gitian.sigs/pull/6~

Once merged, someone with travis powers would just need to enable it, just to build PRs not branches or cron.