### PR TITLE
Add travis check for files touched in PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+os: linux
+language: minimal
+sudo: false
+branches:
+  only:
+    - master
+script:
+- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then scripts/files-touched-check.py; fi

--- a/scripts/files-touched-check.py
+++ b/scripts/files-touched-check.py
@@ -10,7 +10,7 @@ import subprocess
 travis_commit_range = os.getenv('TRAVIS_COMMIT_RANGE')
 if not travis_commit_range:
     print("Travis commit range is empty, exiting...")
-    sys.exit(0)
+    sys.exit(1)
 
 try:
     result = subprocess.check_output(['git', 'diff', '--no-commit-id', '--name-status', '-r', travis_commit_range])
@@ -23,7 +23,7 @@ print(files_added)
 subdir_name = ""
     
 for file_added in files_added:
-    file_added = file_added.split()
+    file_added = file_added.split(maxsplit=1)
 
     # Exclude certain files from some checks
     if file_added[1].startswith("scripts/") or file_added[1] in ['README.md', '.travis.yml', '.gitattributes']:

--- a/scripts/files-touched-check.py
+++ b/scripts/files-touched-check.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import subprocess
+
+travis_commit_range = os.getenv('TRAVIS_COMMIT_RANGE')
+if not travis_commit_range:
+    print("Travis commit range is empty, exiting...")
+    sys.exit(0)
+
+try:
+    result = subprocess.check_output(['git', 'diff', '--no-commit-id', '--name-status', '-r', travis_commit_range])
+except Exception as e:
+    print(e.output)
+    raise e
+
+files_added = result.decode('utf-8').splitlines()
+print(files_added)
+subdir_name = ""
+    
+for file_added in files_added:
+    file_added = file_added.split()
+
+    # Exclude certain files from some checks
+    if file_added[1].startswith("scripts/") or file_added[1] in ['README.md', '.travis.yml', '.gitattributes']:
+        print("Warning: modified non-gitian file", file_added[1])
+        continue
+
+    # Check that files are only added, not modified or deleted
+    if file_added[0] != 'A':
+        print("Error: modified or removed existing file:", file_added[1])
+        sys.exit(1)
+
+    # Check that files added are only added to a single subdirectory name
+    if file_added[1].count('/') > 1:
+        current_subdir = file_added[1].split('/')[1]
+        if not subdir_name:
+            subdir_name = current_subdir
+        if subdir_name != current_subdir:
+            print("Error: files added to multiple subdirectories. Already seen", subdir_name, "got", file_added[1])
+            sys.exit(1)
+    else:
+        print("Warning: filename does not match expected form:", file_added[1])
+
+sys.exit(0)


### PR DESCRIPTION
This adds a script to be run on PRs, which checks that files are only added, not renamed/edited/deleted. It also checks that when files are added to a `version/username/` directory, only one username is used for all files (e.g. if I added sigs to both `0.16.0rc4-linux/meshcollider` and `0.16.0rc4-win-unsigned/achow101` it would fail).

Suggested here: https://github.com/bitcoin-core/gitian.sigs/issues/607#issuecomment-343653605

Excludes the scripts directory, README, travis.yml and .gitattributes files.

~I haven't tested this yet, going to test with travis.~ Both cases seem to be working correctly based on my tests with my repo