### PR TITLE
scripts: replace Travis with Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,15 @@
+container:
+  image: ubuntu:focal
+  cpu: 0.5
+  memory: 256M
+lint_task:
+  use_compute_credits: true
+  only_if: $CIRRUS_BASE_BRANCH == 'main'
+  stateful: false  # https://cirrus-ci.org/guide/writing-tasks/#stateful-tasks
+  setup_script: apt-get update && apt-get install -y git python3
+  merge_base_script:
+    - git fetch $CIRRUS_REPO_CLONE_URL $CIRRUS_BASE_BRANCH
+    - git config --global user.email "ci@ci.ci"
+    - git config --global user.name "ci"
+    - git merge FETCH_HEAD  # Merge base to detect silent merge conflicts
+  lint_script: ./scripts/files-touched-check.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-os: linux
-language: minimal
-branches:
-  only:
-    - master
-script:
-- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then scripts/files-touched-check.py; fi


### PR DESCRIPTION
Looks like Travis isn't running any more. We can replace it with Cirrus, or just remove the config from this repo, as it's not going to see too much more action. The cirrus template is just copied from https://github.com/bitcoin-core/guix.sigs/blob/main/.cirrus.yml. 